### PR TITLE
ENH: Add script to automatically renew SSL certificate

### DIFF
--- a/Jenkins/README.txt
+++ b/Jenkins/README.txt
@@ -21,6 +21,11 @@ Starting an ITK Jenkins instance
 * Create `SSL_KEY` environment variable to point to the location of the
   SSL private key (`export SSL_KEY ${my_location}).
   etc/letsencrypt/archive/itkjenkins.eastus.cloudapp.azure.com/privkey1.pem
+* Create `LETSENCRYPT_EMAIL` environment variable that contains the email address
+  that is contacted when the SSL certificate is about to expire.
+* Set weekly cron job to renew SSL certificate (NOTE: it will actually only be
+  renewed when it is about to expire). The cron job should run
+  `renewSSLcertificate.script`
 * run `build.sh` to create the Jenkins image
 * run `run.sh` to start the nginx and Jenkins servers
 * Get admin temporary password

--- a/Jenkins/nginx.conf
+++ b/Jenkins/nginx.conf
@@ -39,6 +39,11 @@ server {
   ssl_stapling on;
   ssl_stapling_verify on;
 
+  location ^~ /.well-known/acme-challenge {
+    allow all;
+    root /data/letsencrypt;
+  }
+
   location / {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
     add_header X-Frame-Options SAMEORIGIN;

--- a/Jenkins/renewSSLcertificate.script
+++ b/Jenkins/renewSSLcertificate.script
@@ -1,0 +1,15 @@
+#!/bin/bash
+# export real email address that will be notified when certificate
+# is about to expire in bash environment (~/.bashrc).
+#export LETSENCRYPT_EMAIL=me@example.com
+export DNSNAME=itkjenkins.eastus.cloudapp.azure.com
+
+docker run --rm --name letsencrypt \
+    -v ~/etc/letsencrypt:/etc/letsencrypt \
+    -v ~/var/lib/letsencrypt:/var/lib/letsencrypt \
+    -v ~/acme-challenge/:/acme-challenge \
+    certbot/certbot:latest \
+    certonly -n -d $DNSNAME --agree-tos \
+    --webroot -w /acme-challenge \
+    --email $LETSENCRYPT_EMAIL
+

--- a/Jenkins/run.sh
+++ b/Jenkins/run.sh
@@ -31,4 +31,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 docker run --restart unless-stopped -p $jnlp_port:$jnlp_port -p 8080:8080 -v $HOME/itkjenkins:/var/jenkins_home -e "JAVA_OPTS=-Djenkins.slaves.DefaultJnlpSlaveReceiver.disableStrictVerification=true" --name $jenkins_container_name -d jenkins
 
-docker run -p 443:443 -p 80:80 -v $SSL_CERT:/etc/ssl/your_domain_name.pem -v $SSL_KEY:/etc/ssl/your_domain_name.key -v $DIR/nginx.conf:/etc/nginx/conf.d/default.conf --name $nginx_container_name --link itkjenkins:itkjenkins -d nginx
+if [ ! -d ~/acme-challenge/.well-known/acme-challenge/ ]; then
+  mkdir -p ~/acme-challenge/.well-known/acme-challenge/
+fi
+docker run -p 443:443 -p 80:80 -v $SSL_CERT:/etc/ssl/your_domain_name.pem -v $SSL_KEY:/etc/ssl/your_domain_name.key -v ~/acme-challenge:/data/letsencrypt -v $DIR/nginx.conf:/etc/nginx/conf.d/default.conf --name $nginx_container_name --link itkjenkins:itkjenkins -d nginx


### PR DESCRIPTION
Let's encrypt SSL certificates expire every 3 months. A script that
automatically renew the certificates has been added to the repo as
well as instructions about how to use it.